### PR TITLE
feat: add config file support with keybinding modes and file path 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.4
 	github.com/charmbracelet/glamour v0.10.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
+	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 )
 
@@ -41,7 +42,6 @@ require (
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
-	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,6 @@ github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSW
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.7.1/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=
-github.com/yuin/goldmark v1.7.8 h1:iERMLn0/QJeHFhxSt3p6PeN9mGnvIKSpG9YYorDMnic=
-github.com/yuin/goldmark v1.7.8/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=
 github.com/yuin/goldmark v1.7.12 h1:YwGP/rrea2/CnCtUHgjuolG/PnMxdQtPMO5PvaE2/nY=
 github.com/yuin/goldmark v1.7.12/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 github.com/yuin/goldmark-emoji v1.0.5 h1:EMVWyCGPlXJfUXBXpuMu+ii3TIaxbVBnEX9uaDC4cIk=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,10 +1,30 @@
 package config
 
-import "github.com/spf13/viper"
+import (
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/viper"
+)
+
+var AppConfig Config
+var NoteRootPath string
 
 func SetConfig() {
-	viper.SetConfigFile("config")
-	viper.SetConfigFile("yaml")
-	viper.AddConfigPath("$HOME/.config/toney")
-	viper.AddConfigPath("$HOME/.toney")
+	home, _ := os.UserHomeDir()
+
+	viper.AddConfigPath(filepath.Join(home, ".config", "toney"))
+	viper.SetConfigName("config")
+	viper.SetConfigType("yaml")
+
+	if err := viper.ReadInConfig(); err != nil {
+		log.Println("No config file found, using defaults")
+	}
+
+	if err := viper.Unmarshal(&AppConfig); err != nil {
+		log.Fatalf("unable to decode config: %v", err)
+	}
+
+	NoteRootPath = filepath.Join(home, AppConfig.NotePath)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,5 +26,9 @@ func SetConfig() {
 		log.Fatalf("unable to decode config: %v", err)
 	}
 
+	if AppConfig.KeyBinding == "" {
+		AppConfig.KeyBinding = "normal"
+	}
+
 	NoteRootPath = filepath.Join(home, AppConfig.NotePath)
 }

--- a/internal/config/configModels.go
+++ b/internal/config/configModels.go
@@ -7,5 +7,7 @@ type StylesConfig struct {
 }
 
 type Config struct {
-	Styles StylesConfig `mapstructure:"styles"`
+	NotePath string       `mapstructure:"note_path"`
+	Editor   string       `mapstructure:"editor"`
+	Styles   StylesConfig `mapstructure:"styles"`
 }

--- a/internal/config/configModels.go
+++ b/internal/config/configModels.go
@@ -7,7 +7,8 @@ type StylesConfig struct {
 }
 
 type Config struct {
-	NotePath string       `mapstructure:"note_path"`
-	Editor   string       `mapstructure:"editor"`
-	Styles   StylesConfig `mapstructure:"styles"`
+	NotePath   string       `mapstructure:"note_path"`
+	Editor     string       `mapstructure:"editor"`
+	KeyBinding string       `mapstructure:"keybinding"`
+	Styles     StylesConfig `mapstructure:"styles"`
 }

--- a/internal/fileTree/fileTree.go
+++ b/internal/fileTree/fileTree.go
@@ -5,13 +5,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/SourcewareLab/Toney/internal/config"
 	"github.com/SourcewareLab/Toney/internal/styles"
 )
 
 func CreateTree() (*Node, error) {
-	home, _ := os.UserHomeDir()
 
-	root, err := buildTree(nil, filepath.Join(home, ".toney"), 0)
+	root, err := buildTree(nil, config.NoteRootPath, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/models/Viewer/viewer.go
+++ b/internal/models/Viewer/viewer.go
@@ -3,6 +3,7 @@ package viewer
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/SourcewareLab/Toney/internal/messages"
@@ -88,7 +89,9 @@ func (m *Viewer) Header() string {
 func (m *Viewer) ReadFile() string {
 	path := strings.TrimSuffix(m.Path, "/")
 
-	content, err := os.ReadFile(path)
+	homeDir, _ := os.UserHomeDir()
+	fullPath := filepath.Join(homeDir, path)
+	content, err := os.ReadFile(fullPath)
 	if err != nil {
 		fmt.Println(err.Error())
 		content = ([]byte)(fmt.Sprintf("An error occured while reading the file\n%s", err.Error()))

--- a/internal/models/fileExplorer/fileExplorer.go
+++ b/internal/models/fileExplorer/fileExplorer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/SourcewareLab/Toney/internal/config"
@@ -153,7 +154,18 @@ func (m *FileExplorer) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 
-			c := exec.Command(config.AppConfig.Editor, strings.TrimSuffix(filepopup.GetPath(m.CurrentNode), "/"))
+			relPath := strings.TrimSuffix(filepopup.GetPath(m.CurrentNode), "/")
+			homeDir, _ := os.UserHomeDir()
+			var fullPath string
+			if strings.HasPrefix(relPath, "~") {
+				fullPath = filepath.Join(homeDir, relPath[1:])
+			} else if filepath.IsAbs(relPath) {
+				fullPath = relPath
+			} else {
+				fullPath = filepath.Join(homeDir, relPath)
+			}
+
+			c := exec.Command(config.AppConfig.Editor, fullPath)
 			cmd := tea.ExecProcess(c, func(err error) tea.Msg {
 				return messages.EditorClose{
 					Err: err,

--- a/internal/models/fileExplorer/fileExplorer.go
+++ b/internal/models/fileExplorer/fileExplorer.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/SourcewareLab/Toney/internal/config"
 	"github.com/SourcewareLab/Toney/internal/enums"
 	filetree "github.com/SourcewareLab/Toney/internal/fileTree"
 	"github.com/SourcewareLab/Toney/internal/messages"
@@ -83,7 +84,7 @@ func (m *FileExplorer) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 
-			c := exec.Command("nvim", strings.TrimSuffix(filepopup.GetPath(m.CurrentNode), "/"))
+			c := exec.Command(config.AppConfig.Editor, strings.TrimSuffix(filepopup.GetPath(m.CurrentNode), "/"))
 			cmd := tea.ExecProcess(c, func(err error) tea.Msg {
 				return messages.EditorClose{
 					Err: err,

--- a/internal/models/fileExplorer/fileExplorer.go
+++ b/internal/models/fileExplorer/fileExplorer.go
@@ -27,6 +27,18 @@ type FileExplorer struct {
 	CurrentIndex  int
 	VisibleNodes  []*filetree.Node
 	LastSelection string
+	KeyMap        KeyMap
+}
+
+type KeyMap struct {
+	Up     string
+	Down   string
+	Select string
+	Quit   string
+	Create string
+	Delete string
+	Rename string
+	Move   string
 }
 
 func NewFileExplorer(w int, h int) *FileExplorer {
@@ -43,11 +55,68 @@ func NewFileExplorer(w int, h int) *FileExplorer {
 		CurrentNode:  root,
 		CurrentIndex: 0,
 		VisibleNodes: filetree.FlattenVisibleTree(root),
+		KeyMap:       LoadKeyMap(config.AppConfig.KeyBinding),
 	}
 }
 
 func (m FileExplorer) Init() tea.Cmd {
 	return nil
+}
+
+func LoadKeyMap(mode string) KeyMap {
+	var km KeyMap
+	switch mode {
+	case "vim":
+		km = KeyMap{
+			Up:     "k",
+			Down:   "j",
+			Select: "enter",
+			Quit:   "q",
+			Create: "a",
+			Delete: "d",
+			Rename: "r",
+			Move:   "m",
+		}
+	default:
+		km = KeyMap{
+			Up:     "up",
+			Down:   "down",
+			Select: "enter",
+			Quit:   "q",
+			Create: "c",
+			Delete: "d",
+			Rename: "r",
+			Move:   "m",
+		}
+	}
+
+	// Apply overrides
+	// if v, ok := overrides["create"]; ok {
+	// 	km.Create = v
+	// }
+	// if v, ok := overrides["delete"]; ok {
+	// 	km.Delete = v
+	// }
+	// if v, ok := overrides["rename"]; ok {
+	// 	km.Rename = v
+	// }
+	// if v, ok := overrides["move"]; ok {
+	// 	km.Move = v
+	// }
+	// if v, ok := overrides["up"]; ok {
+	// 	km.Up = v
+	// }
+	// if v, ok := overrides["down"]; ok {
+	// 	km.Down = v
+	// }
+	// if v, ok := overrides["select"]; ok {
+	// 	km.Select = v
+	// }
+	// if v, ok := overrides["quit"]; ok {
+	// 	km.Quit = v
+	// }
+
+	return km
 }
 
 func (m *FileExplorer) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -63,21 +132,21 @@ func (m *FileExplorer) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "q", "ctrl+c":
 			return m, tea.Quit
-		case "down":
+		case m.KeyMap.Down:
 			if m.CurrentIndex >= len(m.VisibleNodes)-1 {
 				return m, nil
 			}
 			m.CurrentIndex += 1
 			m.CurrentNode = m.VisibleNodes[m.CurrentIndex]
 			return m, m.SelectionChanged(m.CurrentNode)
-		case "up":
+		case m.KeyMap.Up:
 			if m.CurrentIndex <= 0 {
 				return m, nil
 			}
 			m.CurrentIndex -= 1
 			m.CurrentNode = m.VisibleNodes[m.CurrentIndex]
 			return m, m.SelectionChanged(m.CurrentNode)
-		case "enter":
+		case m.KeyMap.Select:
 			if m.CurrentNode.IsDirectory {
 				m.CurrentNode.IsExpanded = !m.CurrentNode.IsExpanded
 				m.VisibleNodes = filetree.FlattenVisibleTree(m.Root)
@@ -92,14 +161,14 @@ func (m *FileExplorer) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			})
 			return m, cmd
 
-		case "c":
+		case m.KeyMap.Create:
 			return m, func() tea.Msg {
 				return messages.ShowPopupMessage{
 					Type: enums.FileCreate,
 					Curr: m.CurrentNode,
 				}
 			}
-		case "d":
+		case m.KeyMap.Delete:
 			return m, func() tea.Msg {
 				return messages.ShowPopupMessage{
 					Type: enums.FileDelete,
@@ -107,14 +176,14 @@ func (m *FileExplorer) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 
-		case "m":
+		case m.KeyMap.Move:
 			return m, func() tea.Msg {
 				return messages.ShowPopupMessage{
 					Type: enums.FileMove,
 					Curr: m.CurrentNode,
 				}
 			}
-		case "r":
+		case m.KeyMap.Rename:
 			return m, func() tea.Msg {
 				return messages.ShowPopupMessage{
 					Type: enums.FileRename,

--- a/internal/models/filePopup/handlers.go
+++ b/internal/models/filePopup/handlers.go
@@ -3,6 +3,7 @@ package filepopup
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/SourcewareLab/Toney/internal/enums"
@@ -111,19 +112,15 @@ func MapExpanded(new *filetree.Node, old *filetree.Node) {
 	}
 }
 
-func GetPath(n *filetree.Node) string {
-	c := n
-
-	home, _ := os.UserHomeDir()
-
-	path := ""
-
-	for {
-		if c == nil {
-			return home + "/" + path
-		}
-
-		path = c.Name + "/" + path
-		c = c.Parent
+func GetPath(node *filetree.Node) string {
+	if node == nil {
+		return ""
 	}
+
+	segments := []string{}
+	for n := node; n != nil; n = n.Parent {
+		segments = append([]string{n.Name}, segments...)
+	}
+
+	return filepath.Join(segments...)
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,11 @@
 package main
 
-import "github.com/SourcewareLab/Toney/cmd"
+import (
+	"github.com/SourcewareLab/Toney/cmd"
+	"github.com/SourcewareLab/Toney/internal/config"
+)
 
 func main() {
+	config.SetConfig()
 	cmd.Execute()
 }

--- a/run
+++ b/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+go build -o tn main.go
+
+./tn

--- a/run
+++ b/run
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-go build -o tn main.go
-
-./tn


### PR DESCRIPTION
### Summary

Configuration file support to enable user-defined customization.

### Features

- **Config File (`config.yaml`) Support**:
  - Loaded at startup to apply user preferences.
  - Supports keys: `note_path`, `editor`, `keybinding`.

- **Keybinding Modes**:
    - `"normal"`: Arrow key-based navigation (default).
    - `"vim"`: Vim-style navigation with `h/j/k/l`, etc.

- **External Code Editor Support**:
  - File entries open in a user-defined external editor (set via config).


- **In Future**:
  - Users can optionally override individual keys (e.g., `"create" = "a"`). 

