### PR TITLE
feat: CLI

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/SourcewareLab/Toney/internal/config"
 	"github.com/SourcewareLab/Toney/internal/styles"
@@ -17,6 +16,8 @@ import (
 
 type ListOptions struct {
 	Search string
+	All    bool
+	Path   string
 }
 
 func ListCmd() *cobra.Command {
@@ -33,13 +34,23 @@ func ListCmd() *cobra.Command {
 			rootpath := filepath.Join(home, config.AppConfig.General.NotesDir)
 			entries := map[string]os.DirEntry{}
 
+			if opts.Path != "" {
+				rootpath = filepath.Join(rootpath, opts.Path)
+			}
+
 			filepath.WalkDir(rootpath, func(path string, d fs.DirEntry, err error) error {
 				if err != nil {
-					log.Fatalf("failed to read notes directory (%s) : %v", path, err)
+					if opts.Path == "" {
+						log.Fatalf("failed to read notes directory (%s) : %v", path, err)
+					} else {
+						log.Fatalf("failed to read directory given with -p/--path flag (%s) : %v", path, err)
+					}
 				}
 
 				if d.IsDir() {
-					if strings.HasPrefix(d.Name(), ".") && d.Name() != config.AppConfig.General.NotesDir {
+					if d.Name() == config.AppConfig.General.NotesDir {
+						return nil
+					} else if strings.HasPrefix(d.Name(), ".") && !opts.All {
 						return fs.SkipDir
 					}
 				}
@@ -75,6 +86,8 @@ func ListCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opts.Search, "search", "s", "", "fuzzy find a filename that matches the given input")
+	cmd.Flags().BoolVarP(&opts.All, "all", "a", false, "include hidden files in list")
+	cmd.Flags().StringVarP(&opts.Path, "path", "p", "", "list files in given path, path is relative to the `notes_dir`")
 
 	return cmd
 }
@@ -86,7 +99,7 @@ func FormatEntries(entries map[string]os.DirEntry, root string) string {
 	for k, v := range entries {
 		info, _ := v.Info()
 		p, _ := filepath.Rel(root, k)
-		t.Row(p, info.ModTime().Format(time.DateTime), fmt.Sprintf("%dKb", info.Size()))
+		t.Row(p, info.ModTime().Format("02 Jan"), fmt.Sprintf("%dKb", info.Size()))
 	}
 
 	return t.Render()

--- a/cmd/notes/create.go
+++ b/cmd/notes/create.go
@@ -1,0 +1,60 @@
+package notes
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/SourcewareLab/Toney/internal/config"
+	"github.com/spf13/cobra"
+)
+
+type CreateOptions struct {
+	Ext   string
+	Title string
+}
+
+func CreateCmd() *cobra.Command {
+	opts := &CreateOptions{}
+	cmd := &cobra.Command{
+		Use:     "create",
+		Short:   "create a note by relative path",
+		Example: "toney note create mydir/mynote -e txt -t 'My Note'",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := config.SetConfig(); err != nil {
+				return fmt.Errorf("failed to load config: %v\n\n%s", err, "Try running the `toney init` command and try again.")
+			}
+
+			if args[0] == "" {
+				return fmt.Errorf("missing title argument")
+			}
+
+			filename := fmt.Sprintf("%s.%s", args[0], opts.Ext)
+
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("could not get user home directory: %v", err)
+			}
+
+			path := filepath.Join(home, config.AppConfig.General.NotesDir, filename)
+
+			f, err := os.Create(path)
+			if err != nil {
+				return fmt.Errorf("could not create note at %s :-\n%v", path, err)
+			}
+
+			if opts.Title != "" {
+				fmt.Fprintf(f, "# %s\n", opts.Title)
+			}
+
+			fmt.Printf("Successfully created note %s\n", path)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Ext, "ext", "e", "md", "file extension to use")
+	cmd.Flags().StringVarP(&opts.Title, "title", "t", "", "title for the note")
+
+	return cmd
+}

--- a/cmd/notes/delete.go
+++ b/cmd/notes/delete.go
@@ -1,0 +1,44 @@
+package notes
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/SourcewareLab/Toney/internal/config"
+	"github.com/spf13/cobra"
+)
+
+type DeleteOptions struct{}
+
+func DeleteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "delete",
+		Short:   "Delete a note by relative path",
+		Example: "toney note delete mydir/mynote.md",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := config.SetConfig(); err != nil {
+				return fmt.Errorf("failed to load config: %v\n\n%s", err, "Try running the `toney init` command and try again.")
+			}
+
+			if args[0] == "" {
+				return fmt.Errorf("missing filepath parameter")
+			}
+
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("could not get user home directory: %v", err)
+			}
+			path := filepath.Join(home, config.AppConfig.General.NotesDir, args[0])
+			if err := os.Remove(path); err != nil {
+				return fmt.Errorf("failed to delete note at %s :-\n%v", path, err)
+			}
+
+			fmt.Printf("Successfully deleted note %s", path)
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/notes/edit.go
+++ b/cmd/notes/edit.go
@@ -1,0 +1,82 @@
+package notes
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/SourcewareLab/Toney/internal/config"
+	"github.com/spf13/cobra"
+)
+
+type EditOptions struct {
+	Editor string
+}
+
+func EditCmd() *cobra.Command {
+	opts := &EditOptions{}
+	cmd := &cobra.Command{
+		Use:     "edit",
+		Short:   "edit a note by relative path",
+		Example: "toney note edit -e 'alacritty -e bash -c hx'",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := config.SetConfig(); err != nil {
+				return fmt.Errorf("failed to load config: %v\n\n%s", err, "Try running the `toney init` command and try again.")
+			}
+
+			if args[0] == "" {
+				return fmt.Errorf("missing filepath argument")
+			}
+
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("could not get user home directory: %v", err)
+			}
+
+			path := filepath.Join(home, config.AppConfig.General.NotesDir, args[0])
+
+			editorcmd := ""
+			editorargs := make([]string, 0)
+			if opts.Editor == "" {
+				cfg := config.AppConfig.General.Editor
+				if len(cfg) < 1 {
+					return fmt.Errorf("editor command in config is empty")
+				}
+
+				editorcmd = cfg[0]
+
+				if len(cfg) >= 2 {
+					editorargs = cfg[1:]
+				}
+			} else {
+				cmdargs := strings.Split(opts.Editor, " ")
+
+				editorcmd = cmdargs[0]
+				if len(cmdargs) >= 2 {
+					editorargs = cmdargs[1:]
+				}
+			}
+
+			editorargs = append(editorargs, path)
+
+			execcmd := exec.Command(editorcmd, editorargs...)
+
+			execcmd.Stdin = os.Stdin
+			execcmd.Stdout = os.Stdout
+			execcmd.Stderr = os.Stderr
+
+			if err := execcmd.Run(); err != nil {
+				os.Exit(1)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Editor, "editor", "e", "", "editor to open note, will be split ' ' and then computed")
+
+	return cmd
+}

--- a/cmd/notes/list.go
+++ b/cmd/notes/list.go
@@ -1,4 +1,4 @@
-package cmd
+package notes
 
 import (
 	"fmt"
@@ -25,9 +25,9 @@ func ListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all notes in the notes directory",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := config.SetConfig(); err != nil {
-				log.Fatalf("failed to load config: %v\n%s", err, "Try running the `toney init` command and try again.")
+				return fmt.Errorf("failed to load config: %v\n\n%s", err, "Try running the `toney init` command and try again.")
 			}
 
 			home, _ := os.UserHomeDir()
@@ -82,6 +82,7 @@ func ListCmd() *cobra.Command {
 			content := FormatEntries(filteredEntries, rootpath)
 
 			fmt.Println(content)
+			return nil
 		},
 	}
 

--- a/cmd/notes/notes.go
+++ b/cmd/notes/notes.go
@@ -1,0 +1,20 @@
+package notes
+
+import "github.com/spf13/cobra"
+
+func NotesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "note",
+		Short: "Manage your notes",
+	}
+
+	cmd.AddCommand(
+		ListCmd(),
+		DeleteCmd(),
+		CreateCmd(),
+		EditCmd(),
+		RenderCmd(),
+	)
+
+	return cmd
+}

--- a/cmd/notes/render.go
+++ b/cmd/notes/render.go
@@ -1,0 +1,63 @@
+package notes
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/SourcewareLab/Toney/internal/config"
+	"github.com/charmbracelet/glamour"
+	"github.com/spf13/cobra"
+)
+
+type RenderOptions struct {
+	Raw bool
+}
+
+func RenderCmd() *cobra.Command {
+	opts := &RenderOptions{}
+	cmd := &cobra.Command{
+		Use:     "render",
+		Short:   "render a note by relative path",
+		Example: "toney note render mydir/mynote --raw",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := config.SetConfig(); err != nil {
+				return fmt.Errorf("failed to load config: %v\n\n%s", err, "Try running the `toney init` command and try again.")
+			}
+
+			if args[0] == "" {
+				return fmt.Errorf("missing title argument")
+			}
+
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("could not get user home directory: %v", err)
+			}
+
+			path := filepath.Join(home, config.AppConfig.General.NotesDir, args[0])
+
+			content, err := os.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("could not create note at %s :-\n%v", path, err)
+			}
+
+			if opts.Raw {
+				fmt.Print(string(content))
+			} else {
+				r, err := glamour.NewTermRenderer(glamour.WithStyles(config.ToGlamourStyle(config.AppConfig.Styles.Renderer)))
+				if err != nil {
+					return fmt.Errorf("could not create renderer from config :-\n%v", err)
+				}
+
+				fmt.Print(r.Render(string(content)))
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVarP(&opts.Raw, "raw", "r", false, "view raw file without styles")
+
+	return cmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/SourcewareLab/Toney/cmd/notes"
+	"github.com/SourcewareLab/Toney/cmd/tasks"
 	"github.com/SourcewareLab/Toney/internal/config"
 	"github.com/SourcewareLab/Toney/internal/models"
 	tea "github.com/charmbracelet/bubbletea"
@@ -59,6 +60,7 @@ func RootCmd() *cobra.Command {
 		InitCmd(),
 		DumpCmd(),
 		notes.NotesCmd(),
+		tasks.TasksCmd(),
 	)
 
 	return cmd

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/SourcewareLab/Toney/cmd/notes"
 	"github.com/SourcewareLab/Toney/internal/config"
 	"github.com/SourcewareLab/Toney/internal/models"
 	tea "github.com/charmbracelet/bubbletea"
@@ -55,17 +56,14 @@ func RootCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		ListCmd(),
-		DumpCmd(),
 		InitCmd(),
+		DumpCmd(),
+		notes.NotesCmd(),
 	)
 
 	return cmd
 }
 
 func Execute() {
-	if err := fang.Execute(context.Background(), RootCmd()); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
+	fang.Execute(context.Background(), RootCmd())
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/SourcewareLab/Toney/cmd/notes"
+	synccmd "github.com/SourcewareLab/Toney/cmd/sync"
 	"github.com/SourcewareLab/Toney/cmd/tasks"
 	"github.com/SourcewareLab/Toney/internal/config"
 	"github.com/SourcewareLab/Toney/internal/models"
@@ -61,6 +62,7 @@ func RootCmd() *cobra.Command {
 		DumpCmd(),
 		notes.NotesCmd(),
 		tasks.TasksCmd(),
+		synccmd.SyncCmd(),
 	)
 
 	return cmd

--- a/cmd/sync/init.go
+++ b/cmd/sync/init.go
@@ -1,0 +1,38 @@
+package synccmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/SourcewareLab/Toney/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func InitCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "initialize sync settings",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := config.SetConfig(); err != nil {
+				return fmt.Errorf("failed to load config: %v\n\n%s", err, "Try running the `toney init` command and try again.")
+			}
+
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return err
+			}
+
+			path := filepath.Join(home, config.AppConfig.General.NotesDir)
+
+			command := exec.Command("git", "init")
+			command.Dir = path
+
+			err = command.Run()
+			return err
+		},
+	}
+
+	return cmd
+}

--- a/cmd/sync/push.go
+++ b/cmd/sync/push.go
@@ -1,0 +1,42 @@
+package synccmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/SourcewareLab/Toney/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func PushCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "push",
+		Short: "push to the remote url",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := config.SetConfig(); err != nil {
+				return fmt.Errorf("failed to load config: %v\n\n%s", err, "Try running the `toney init` command and try again.")
+			}
+
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return err
+			}
+
+			path := filepath.Join(home, config.AppConfig.General.NotesDir)
+
+			command := exec.Command("git", "push", "-u", "origin", "HEAD")
+			command.Dir = path
+
+			err = command.Run()
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/sync/remote.go
+++ b/cmd/sync/remote.go
@@ -1,0 +1,62 @@
+package synccmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/SourcewareLab/Toney/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func RemoteCmd() *cobra.Command {
+	var IsSetting bool
+	cmd := &cobra.Command{
+		Use:   "remote",
+		Short: "set the remote url",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := config.SetConfig(); err != nil {
+				return fmt.Errorf("failed to load config: %v\n\n%s", err, "Try running the `toney init` command and try again.")
+			}
+
+			if args[0] == "" {
+				return fmt.Errorf("Empty remote url found")
+			}
+
+			remote := args[0]
+
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return err
+			}
+
+			path := filepath.Join(home, config.AppConfig.General.NotesDir)
+
+			if IsSetting {
+				command := exec.Command("git", "remote", "set-url", "origin", remote)
+				command.Dir = path
+
+				err = command.Run()
+				if err != nil {
+					return err
+				}
+			} else {
+				command := exec.Command("git", "remote", "add", "origin", remote)
+				command.Dir = path
+
+				err = command.Run()
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVarP(&IsSetting, "set", "s", false, "set one you are changing the remote url")
+
+	return cmd
+}

--- a/cmd/sync/resync.go
+++ b/cmd/sync/resync.go
@@ -1,0 +1,42 @@
+package synccmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/SourcewareLab/Toney/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func ResyncCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "resync",
+		Short: "syncs notes state",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := config.SetConfig(); err != nil {
+				return fmt.Errorf("failed to load config: %v\n\n%s", err, "Try running the `toney init` command and try again.")
+			}
+
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return err
+			}
+
+			path := filepath.Join(home, config.AppConfig.General.NotesDir)
+
+			command := exec.Command("git", "pull", "--rebase")
+			command.Dir = path
+
+			err = command.Run()
+			if err != nil {
+				return err
+			}
+
+			return err
+		},
+	}
+
+	return cmd
+}

--- a/cmd/sync/save.go
+++ b/cmd/sync/save.go
@@ -1,0 +1,47 @@
+package synccmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/SourcewareLab/Toney/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func SaveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "save",
+		Short: "saves current notes state",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := config.SetConfig(); err != nil {
+				return fmt.Errorf("failed to load config: %v\n\n%s", err, "Try running the `toney init` command and try again.")
+			}
+
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return err
+			}
+
+			path := filepath.Join(home, config.AppConfig.General.NotesDir)
+
+			command := exec.Command("git", "add", ".")
+			command.Dir = path
+
+			err = command.Run()
+			if err != nil {
+				return err
+			}
+
+			command = exec.Command("git", "commit", "-m", fmt.Sprintf("Saved state at %s", time.Now().Format("15:04:05 02 Jan")))
+			command.Dir = path
+
+			err = command.Run()
+			return err
+		},
+	}
+
+	return cmd
+}

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -12,6 +12,7 @@ func SyncCmd() *cobra.Command {
 		InitCmd(),
 		SaveCmd(),
 		RemoteCmd(),
+		PushCmd(),
 	)
 
 	return cmd

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -10,6 +10,7 @@ func SyncCmd() *cobra.Command {
 
 	cmd.AddCommand(
 		InitCmd(),
+		SaveCmd(),
 	)
 
 	return cmd

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -1,0 +1,16 @@
+package synccmd
+
+import "github.com/spf13/cobra"
+
+func SyncCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sync",
+		Short: "sync your notes and tasks",
+	}
+
+	cmd.AddCommand(
+		InitCmd(),
+	)
+
+	return cmd
+}

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -11,6 +11,7 @@ func SyncCmd() *cobra.Command {
 	cmd.AddCommand(
 		InitCmd(),
 		SaveCmd(),
+		RemoteCmd(),
 	)
 
 	return cmd

--- a/cmd/tasks/create.go
+++ b/cmd/tasks/create.go
@@ -1,0 +1,84 @@
+package tasks
+
+import (
+	"fmt"
+
+	"github.com/SourcewareLab/Toney/internal/config"
+	"github.com/SourcewareLab/Toney/internal/enums"
+	"github.com/SourcewareLab/Toney/internal/models/daily"
+	"github.com/SourcewareLab/Toney/internal/styles"
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+)
+
+type CreateOptions struct {
+	Title       string
+	Description string
+	Status      enums.TaskStatus
+	Type        enums.TaskType
+}
+
+func CreatCmd() *cobra.Command {
+	opts := &CreateOptions{}
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "create a task",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := config.SetConfig(); err != nil {
+				return fmt.Errorf("failed to load config: %v\n\n%s", err, "Try running the `toney init` command and try again.")
+			}
+
+			grps := make([]*huh.Group, 0)
+
+			if opts.Title == "" {
+				grps = append(grps, huh.NewGroup(huh.NewInput().
+					Title("Title").
+					Value(&opts.Title)))
+			}
+
+			if opts.Description == "" {
+				grps = append(grps, huh.NewGroup(huh.NewText().
+					Title("Description").
+					Value(&opts.Description)))
+			}
+
+			grps = append(grps, huh.NewGroup(huh.NewSelect[enums.TaskStatus]().
+				Title("Status").
+				Options(
+					huh.NewOption[enums.TaskStatus]("Pending", enums.Pending),
+					huh.NewOption[enums.TaskStatus]("Started", enums.Started),
+					huh.NewOption[enums.TaskStatus]("Abandoned", enums.Abandoned),
+					huh.NewOption[enums.TaskStatus]("Complete", enums.Complete),
+				).
+				Value(&opts.Status)),
+				huh.NewGroup(
+					huh.NewSelect[enums.TaskType]().
+						Title("Type").
+						Options(
+							huh.NewOption[enums.TaskType]("Unique", enums.UniqueTask),
+							huh.NewOption[enums.TaskType]("Recurring", enums.RecurringTask),
+						).
+						Value(&opts.Type)))
+
+			form := huh.NewForm(grps...).WithTheme(styles.HuhTheme())
+			form.Run()
+
+			tasks := daily.GetItems()
+			tasks = append(tasks, daily.Task{
+				TaskTitle: opts.Title,
+				TaskType:  opts.Type,
+				TaskDesc:  opts.Description,
+				Status:    opts.Status,
+			})
+
+			daily.WriteItems(tasks)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Title, "title", "t", "", "title for the task")
+	cmd.Flags().StringVarP(&opts.Description, "desc", "d", "", "description for the task")
+
+	return cmd
+}

--- a/cmd/tasks/delete.go
+++ b/cmd/tasks/delete.go
@@ -1,0 +1,68 @@
+package tasks
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/SourcewareLab/Toney/internal/config"
+	"github.com/SourcewareLab/Toney/internal/models/daily"
+	"github.com/SourcewareLab/Toney/internal/styles"
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+)
+
+type DeleteOptions struct {
+	ID      int
+	Confirm bool
+}
+
+func DeleteCmd() *cobra.Command {
+	opts := &DeleteOptions{}
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "delete a task",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := config.SetConfig(); err != nil {
+				return fmt.Errorf("failed to load config: %v\n\n%s", err, "Try running the `toney init` command and try again.")
+			}
+
+			tasks := daily.GetItems()
+
+			options := make([]huh.Option[int], 0)
+			for _, v := range tasks {
+				options = append(options, huh.NewOption[int](v.Title(), v.ID))
+			}
+
+			form := huh.NewForm(
+				huh.NewGroup(
+					huh.NewSelect[int]().
+						Title("Choose task to delete").
+						Value(&opts.ID).
+						Options(
+							options...,
+						),
+				),
+				huh.NewGroup(
+					huh.NewConfirm().
+						Title(fmt.Sprintf("Delete Task: `%s` ?", tasks[opts.ID].Title())).
+						Value(&opts.Confirm),
+				),
+			).WithTheme(styles.HuhTheme())
+
+			form.Run()
+
+			if !opts.Confirm {
+				return nil
+			}
+
+			fmt.Printf("Deleted Task: `%s`\n", tasks[opts.ID].Title())
+			tasks = slices.Delete(tasks, opts.ID, opts.ID+1)
+
+			daily.WriteItems(tasks)
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/tasks/delete.go
+++ b/cmd/tasks/delete.go
@@ -56,7 +56,7 @@ func DeleteCmd() *cobra.Command {
 			}
 
 			fmt.Printf("Deleted Task: `%s`\n", tasks[opts.ID].Title())
-			tasks = slices.Delete(tasks, opts.ID, opts.ID+1)
+			tasks = slices.Delete(tasks, opts.ID-1, opts.ID)
 
 			daily.WriteItems(tasks)
 

--- a/cmd/tasks/edit.go
+++ b/cmd/tasks/edit.go
@@ -1,0 +1,123 @@
+package tasks
+
+import (
+	"fmt"
+
+	"github.com/SourcewareLab/Toney/internal/config"
+	"github.com/SourcewareLab/Toney/internal/enums"
+	"github.com/SourcewareLab/Toney/internal/models/daily"
+	"github.com/SourcewareLab/Toney/internal/styles"
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+)
+
+type EditOptions struct {
+	ID          int
+	Title       string
+	Description string
+	Status      enums.TaskStatus
+	Type        enums.TaskType
+}
+
+func EditCmd() *cobra.Command {
+	opts := &EditOptions{}
+	cmd := &cobra.Command{
+		Use:   "edit",
+		Short: "edit a task",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := config.SetConfig(); err != nil {
+				return fmt.Errorf("failed to load config: %v\n\n%s", err, "Try running the `toney init` command and try again.")
+			}
+
+			tasks := daily.GetItems()
+
+			options := make([]huh.Option[int], 0)
+			for k, v := range tasks {
+				options = append(options, huh.NewOption(v.Title(), k))
+			}
+
+			selectform := huh.NewForm(
+				huh.NewGroup(
+					huh.NewSelect[int]().
+						Title("Select a task to edit").
+						Value(&opts.ID).
+						Options(
+							options...,
+						),
+				),
+			).WithTheme(styles.HuhTheme())
+
+			selectform.Run()
+
+			opts.Title = tasks[opts.ID].TaskTitle
+			opts.Description = tasks[opts.ID].TaskDesc
+			opts.Type = tasks[opts.ID].TaskType
+			opts.Status = tasks[opts.ID].Status
+
+			statusOpts := make([]huh.Option[enums.TaskStatus], 0)
+			for i := range 4 {
+				opt := huh.NewOption(enums.TaskStatusMap[enums.TaskStatus(i)], enums.TaskStatus(i)).Selected(false)
+
+				if enums.TaskStatus(i) == opts.Status {
+					opt.Selected(true)
+				}
+
+				statusOpts = append(statusOpts, opt)
+			}
+
+			typeOpts := make([]huh.Option[enums.TaskType], 0)
+			for i := range 2 {
+				opt := huh.NewOption(enums.TaskTypeMap[enums.TaskType(i)], enums.TaskType(i)).Selected(false)
+
+				if enums.TaskType(i) == opts.Type {
+					opt.Selected(true)
+				}
+
+				typeOpts = append(typeOpts, opt)
+			}
+
+			taskform := huh.NewForm(
+				huh.NewGroup(
+					huh.NewInput().
+						Title("Title").
+						Value(&opts.Title),
+				),
+				huh.NewGroup(
+					huh.NewText().
+						Title("Description").
+						Value(&opts.Description),
+				),
+				huh.NewGroup(huh.NewSelect[enums.TaskStatus]().
+					Title("Status").
+					Options(
+						statusOpts...,
+					).
+					Value(&opts.Status)),
+				huh.NewGroup(
+					huh.NewSelect[enums.TaskType]().
+						Title("Type").
+						Options(
+							typeOpts...,
+						).
+						Value(&opts.Type)),
+			).WithTheme(styles.HuhTheme())
+
+			taskform.Run()
+
+			task := daily.Task{
+				TaskType:  opts.Type,
+				TaskTitle: opts.Title,
+				TaskDesc:  opts.Description,
+				Status:    opts.Status,
+			}
+
+			tasks[opts.ID] = task
+
+			daily.WriteItems(tasks)
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/tasks/list.go
+++ b/cmd/tasks/list.go
@@ -1,11 +1,6 @@
 package tasks
 
 import (
-	"fmt"
-
-	"github.com/SourcewareLab/Toney/internal/config"
-	"github.com/SourcewareLab/Toney/internal/models/daily"
-	"github.com/charmbracelet/bubbles/list"
 	"github.com/spf13/cobra"
 )
 
@@ -21,21 +16,21 @@ func ListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List all current tasks",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := config.SetConfig(); err != nil {
-				return fmt.Errorf("failed to load config: %v\n\n%s", err, "Try running the `toney init` command and try again.")
-			}
-
-			tasks := daily.GetItems().ItemsAsList()
-			ht := daily.TaskDelegate{}.Height() + daily.TaskDelegate{}.Spacing()
-
-			lst := list.New(tasks, daily.TaskDelegate{}, 1000, len(tasks)*ht)
-			lst.SetShowTitle(false)
-			lst.SetShowHelp(false)
-			lst.SetShowFilter(false)
-			lst.SetShowStatusBar(false)
-			lst.SetShowPagination(false)
-
-			fmt.Printf("\n\n%s\n\n", lst.View())
+			// if err := config.SetConfig(); err != nil {
+			// 	return fmt.Errorf("failed to load config: %v\n\n%s", err, "Try running the `toney init` command and try again.")
+			// }
+			//
+			// tasks := daily.GetItems().ItemsAsList()
+			// ht := daily.TaskDelegate{}.Height() + daily.TaskDelegate{}.Spacing()
+			//
+			// lst := list.New(tasks, daily.TaskDelegate{}, 1000, len(tasks)*ht)
+			// lst.SetShowTitle(false)
+			// lst.SetShowHelp(false)
+			// lst.SetShowFilter(false)
+			// lst.SetShowStatusBar(false)
+			// lst.SetShowPagination(false)
+			//
+			// fmt.Printf("\n\n%s\n\n", lst.View())
 			return nil
 		},
 	}

--- a/cmd/tasks/list.go
+++ b/cmd/tasks/list.go
@@ -1,6 +1,16 @@
 package tasks
 
 import (
+	"fmt"
+	"io"
+
+	"github.com/SourcewareLab/Toney/internal/config"
+	"github.com/SourcewareLab/Toney/internal/enums"
+	"github.com/SourcewareLab/Toney/internal/models/daily"
+	"github.com/SourcewareLab/Toney/internal/styles"
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 )
 
@@ -16,24 +26,70 @@ func ListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List all current tasks",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// if err := config.SetConfig(); err != nil {
-			// 	return fmt.Errorf("failed to load config: %v\n\n%s", err, "Try running the `toney init` command and try again.")
-			// }
-			//
-			// tasks := daily.GetItems().ItemsAsList()
-			// ht := daily.TaskDelegate{}.Height() + daily.TaskDelegate{}.Spacing()
-			//
-			// lst := list.New(tasks, daily.TaskDelegate{}, 1000, len(tasks)*ht)
-			// lst.SetShowTitle(false)
-			// lst.SetShowHelp(false)
-			// lst.SetShowFilter(false)
-			// lst.SetShowStatusBar(false)
-			// lst.SetShowPagination(false)
-			//
-			// fmt.Printf("\n\n%s\n\n", lst.View())
+			if err := config.SetConfig(); err != nil {
+				return fmt.Errorf("failed to load config: %v\n\n%s", err, "Try running the `toney init` command and try again.")
+			}
+
+			dl := CmdDelegate{}
+			ht := dl.Height() + dl.Spacing()
+			tasks := daily.TaskToItems(daily.GetItems())
+
+			lst := list.New(tasks, dl, 1000, len(tasks)*ht)
+			lst.SetShowTitle(false)
+			lst.SetShowHelp(false)
+			lst.SetShowFilter(false)
+			lst.SetShowStatusBar(false)
+			lst.SetShowPagination(false)
+
+			fmt.Printf("\n\n%s\n\n", lst.View())
 			return nil
 		},
 	}
 
 	return cmd
+}
+
+type CmdDelegate struct{}
+
+func (d CmdDelegate) Height() int                               { return 1 }
+func (d CmdDelegate) Spacing() int                              { return 1 }
+func (d CmdDelegate) Update(msg tea.Msg, m *list.Model) tea.Cmd { return nil }
+
+func (d CmdDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) {
+	if len(m.Items()) == 0 {
+		return
+	}
+
+	t, ok := item.(daily.Task)
+	if !ok {
+		return
+	}
+
+	text := ""
+	cfg := config.AppConfig.Styles.Icons.TaskIcons
+
+	switch t.Status {
+	case enums.Complete:
+		text += styles.CompletedStyle().Title.Render(fmt.Sprintf("%d. %s | %s", t.ID, cfg.CompletedIcon, Shorten(t.Title(), 35)))
+	case enums.Pending:
+		text += styles.PendingStyle().Title.Render(fmt.Sprintf("%d. %s | %s", t.ID, cfg.PendingIcon, Shorten(t.Title(), 35)))
+	case enums.Started:
+		text += styles.StartedStyle().Title.Render(fmt.Sprintf("%d. %s | %s", t.ID, cfg.StartedIcon, Shorten(t.Title(), 35)))
+	case enums.Abandoned:
+		text += styles.AbandonedStyle().Title.Render(fmt.Sprintf("%d. %s | %s", t.ID, cfg.AbandonedIcon, Shorten(t.Title(), 35)))
+	}
+
+	text = lipgloss.NewStyle().MarginLeft(3).Render(text)
+
+	io.WriteString(w, text)
+}
+
+func Shorten(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return lipgloss.NewStyle().Width(maxLen).Render(s)
+	}
+	if maxLen <= 1 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-1] + "…"
 }

--- a/cmd/tasks/list.go
+++ b/cmd/tasks/list.go
@@ -1,0 +1,44 @@
+package tasks
+
+import (
+	"fmt"
+
+	"github.com/SourcewareLab/Toney/internal/config"
+	"github.com/SourcewareLab/Toney/internal/models/daily"
+	"github.com/charmbracelet/bubbles/list"
+	"github.com/spf13/cobra"
+)
+
+type ListOptions struct {
+	Search string
+	All    bool
+	Path   string
+}
+
+func ListCmd() *cobra.Command {
+	// opts := &ListOptions{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all current tasks",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := config.SetConfig(); err != nil {
+				return fmt.Errorf("failed to load config: %v\n\n%s", err, "Try running the `toney init` command and try again.")
+			}
+
+			tasks := daily.GetItems().ItemsAsList()
+			ht := daily.TaskDelegate{}.Height() + daily.TaskDelegate{}.Spacing()
+
+			lst := list.New(tasks, daily.TaskDelegate{}, 1000, len(tasks)*ht)
+			lst.SetShowTitle(false)
+			lst.SetShowHelp(false)
+			lst.SetShowFilter(false)
+			lst.SetShowStatusBar(false)
+			lst.SetShowPagination(false)
+
+			fmt.Printf("\n\n%s\n\n", lst.View())
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/tasks/list.go
+++ b/cmd/tasks/list.go
@@ -3,6 +3,9 @@ package tasks
 import (
 	"fmt"
 	"io"
+	"os"
+	"strconv"
+	"strings"
 
 	"github.com/SourcewareLab/Toney/internal/config"
 	"github.com/SourcewareLab/Toney/internal/enums"
@@ -15,13 +18,12 @@ import (
 )
 
 type ListOptions struct {
-	Search string
-	All    bool
-	Path   string
+	Raw     bool
+	Verbose bool
 }
 
 func ListCmd() *cobra.Command {
-	// opts := &ListOptions{}
+	opts := &ListOptions{}
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all current tasks",
@@ -30,7 +32,7 @@ func ListCmd() *cobra.Command {
 				return fmt.Errorf("failed to load config: %v\n\n%s", err, "Try running the `toney init` command and try again.")
 			}
 
-			dl := CmdDelegate{}
+			dl := CmdDelegate{Verbose: opts.Verbose}
 			ht := dl.Height() + dl.Spacing()
 			tasks := daily.TaskToItems(daily.GetItems())
 
@@ -41,17 +43,34 @@ func ListCmd() *cobra.Command {
 			lst.SetShowStatusBar(false)
 			lst.SetShowPagination(false)
 
+			if opts.Raw {
+				path := daily.GetPath()
+				content, _ := os.ReadFile(path)
+				fmt.Println(string(content))
+				return nil
+			}
 			fmt.Printf("\n\n%s\n\n", lst.View())
 			return nil
 		},
 	}
 
+	cmd.Flags().BoolVarP(&opts.Raw, "raw", "r", false, "get raw output of the daily tasks file")
+	cmd.Flags().BoolVarP(&opts.Verbose, "verbose", "v", false, "verbose rendering of tasks, shows description as well")
+
 	return cmd
 }
 
-type CmdDelegate struct{}
+type CmdDelegate struct {
+	Verbose bool
+}
 
-func (d CmdDelegate) Height() int                               { return 1 }
+func (d CmdDelegate) Height() int {
+	if d.Verbose {
+		return 2
+	}
+
+	return 1
+}
 func (d CmdDelegate) Spacing() int                              { return 1 }
 func (d CmdDelegate) Update(msg tea.Msg, m *list.Model) tea.Cmd { return nil }
 
@@ -68,18 +87,51 @@ func (d CmdDelegate) Render(w io.Writer, m list.Model, index int, item list.Item
 	text := ""
 	cfg := config.AppConfig.Styles.Icons.TaskIcons
 
+	icon := ""
 	switch t.Status {
 	case enums.Complete:
-		text += styles.CompletedStyle().Title.Render(fmt.Sprintf("%d. %s | %s", t.ID, cfg.CompletedIcon, Shorten(t.Title(), 35)))
+		icon = cfg.CompletedIcon
 	case enums.Pending:
-		text += styles.PendingStyle().Title.Render(fmt.Sprintf("%d. %s | %s", t.ID, cfg.PendingIcon, Shorten(t.Title(), 35)))
+		icon = cfg.PendingIcon
 	case enums.Started:
-		text += styles.StartedStyle().Title.Render(fmt.Sprintf("%d. %s | %s", t.ID, cfg.StartedIcon, Shorten(t.Title(), 35)))
+		icon = cfg.StartedIcon
 	case enums.Abandoned:
-		text += styles.AbandonedStyle().Title.Render(fmt.Sprintf("%d. %s | %s", t.ID, cfg.AbandonedIcon, Shorten(t.Title(), 35)))
+		icon = cfg.AbandonedIcon
 	}
 
-	text = lipgloss.NewStyle().MarginLeft(3).Render(text)
+	taskText := fmt.Sprintf("%s | %s", icon, Shorten(t.Title(), 35))
+
+	switch t.Status {
+	case enums.Complete:
+		taskText = styles.CompletedStyle().Title.Render(taskText)
+	case enums.Pending:
+		taskText = styles.PendingStyle().Title.Render(taskText)
+	case enums.Started:
+		taskText = styles.StartedStyle().Title.Render(taskText)
+	case enums.Abandoned:
+		taskText = styles.AbandonedStyle().Title.Render(taskText)
+	}
+
+	if d.Verbose {
+		descText := fmt.Sprintf("\n%s      %s", strings.Repeat(" ", len(strconv.Itoa(t.ID))), t.Description()) // All the spacing to align correctly with title
+
+		switch t.Status {
+		case enums.Complete:
+			descText = styles.CompletedStyle().Desc.Render(descText)
+		case enums.Pending:
+			descText = styles.PendingStyle().Desc.Render(descText)
+		case enums.Started:
+			descText = styles.StartedStyle().Desc.Render(descText)
+		case enums.Abandoned:
+			descText = styles.AbandonedStyle().Desc.Render(descText)
+		}
+
+		taskText += descText
+	}
+
+	text += taskText
+
+	text = lipgloss.NewStyle().MarginLeft(3).Render(fmt.Sprintf("%d. %s", t.ID, text))
 
 	io.WriteString(w, text)
 }

--- a/cmd/tasks/tasks.go
+++ b/cmd/tasks/tasks.go
@@ -12,6 +12,7 @@ func TasksCmd() *cobra.Command {
 		ListCmd(),
 		CreatCmd(),
 		DeleteCmd(),
+		EditCmd(),
 	)
 
 	return cmd

--- a/cmd/tasks/tasks.go
+++ b/cmd/tasks/tasks.go
@@ -11,6 +11,7 @@ func TasksCmd() *cobra.Command {
 	cmd.AddCommand(
 		ListCmd(),
 		CreatCmd(),
+		DeleteCmd(),
 	)
 
 	return cmd

--- a/cmd/tasks/tasks.go
+++ b/cmd/tasks/tasks.go
@@ -10,6 +10,7 @@ func TasksCmd() *cobra.Command {
 
 	cmd.AddCommand(
 		ListCmd(),
+		CreatCmd(),
 	)
 
 	return cmd

--- a/cmd/tasks/tasks.go
+++ b/cmd/tasks/tasks.go
@@ -1,0 +1,16 @@
+package tasks
+
+import "github.com/spf13/cobra"
+
+func TasksCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tasks",
+		Short: "Manage your tasks",
+	}
+
+	cmd.AddCommand(
+		ListCmd(),
+	)
+
+	return cmd
+}

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jszwec/csvutil v1.10.0 // indirect
 	github.com/lithammer/fuzzysearch v1.1.8 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,18 +16,22 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
+	github.com/catppuccin/go v0.3.0 // indirect
 	github.com/charmbracelet/bubbletea/v2 v2.0.0-beta.3 // indirect
 	github.com/charmbracelet/colorprofile v0.3.1 // indirect
 	github.com/charmbracelet/fang v0.4.0 // indirect
+	github.com/charmbracelet/huh v0.7.0 // indirect
 	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.3 // indirect
 	github.com/charmbracelet/x/ansi v0.9.3 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.14-0.20250501183327-ad3bc78c6a81 // indirect
 	github.com/charmbracelet/x/exp/charmtone v0.0.0-20250603201427-c31516f43444 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
+	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
 	github.com/charmbracelet/x/input v0.3.5-0.20250424101541-abb4d9a9b197 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.1 // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
@@ -39,6 +43,7 @@ require (
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
+	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/mango v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jszwec/csvutil v1.10.0 h1:upMDUxhQKqZ5ZDCs/wy+8Kib8rZR8I8lOR34yJkdqhI=
+github.com/jszwec/csvutil v1.10.0/go.mod h1:/E4ONrmGkwmWsk9ae9jpXnv9QT8pLHEPcCirMFhxG9I=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWp
 github.com/aymanbagabas/go-udiff v0.2.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
+github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
+github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/charmbracelet/bubbles v0.21.0 h1:9TdC97SdRVg/1aaXNVWfFH3nnLAwOXr8Fn6u6mfQdFs=
 github.com/charmbracelet/bubbles v0.21.0/go.mod h1:HF+v6QUR4HkEpz62dx7ym2xc71/KBHg+zKwJtMw+qtg=
 github.com/charmbracelet/bubbletea v1.3.4 h1:kCg7B+jSCFPLYRA52SDZjr51kG/fMUEoPoZrkaDHyoI=
@@ -30,6 +32,8 @@ github.com/charmbracelet/fang v0.4.0 h1:boBxmdcFghTeotqkD2itXi7SMBozdIlcslRqjboS
 github.com/charmbracelet/fang v0.4.0/go.mod h1:9gCUAHmVx5BwSafeyNr3GI0GgvlB1WYjL21SkPp1jyU=
 github.com/charmbracelet/glamour v0.10.0 h1:MtZvfwsYCx8jEPFJm3rIBFIMZUfUJ765oX8V6kXldcY=
 github.com/charmbracelet/glamour v0.10.0/go.mod h1:f+uf+I/ChNmqo087elLnVdCiVgjSKWuXa/l6NU2ndYk=
+github.com/charmbracelet/huh v0.7.0 h1:W8S1uyGETgj9Tuda3/JdVkc3x7DBLZYPZc4c+/rnRdc=
+github.com/charmbracelet/huh v0.7.0/go.mod h1:UGC3DZHlgOKHvHC07a5vHag41zzhpPFj34U92sOmyuk=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 h1:ZR7e0ro+SZZiIZD7msJyA+NjkCNNavuiPBLgerbOziE=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834/go.mod h1:aKC/t2arECF6rNOnaKaVU6y4t4ZeHQzqfxedE/VkVhA=
 github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.2 h1:vq2enzx1Hr3UenVefpPEf+E2xMmqtZoSHhx8IE+V8ug=
@@ -51,6 +55,8 @@ github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91/go.mod 
 github.com/charmbracelet/x/exp/golden v0.0.0-20241212170349-ad4b7ae0f25f h1:UytXHv0UxnsDFmL/7Z9Q5SBYPwSuRLXHbwx+6LycZ2w=
 github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf h1:rLG0Yb6MQSDKdB52aGX55JT1oi0P0Kuaj7wi1bLUpnI=
 github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf/go.mod h1:B3UgsnsBZS/eX42BlaNiJkD1pPOUa+oF1IYC6Yd2CEU=
+github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 h1:qko3AQ4gK1MTS/de7F5hPGx6/k1u0w4TeYmBFwzYVP4=
+github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0/go.mod h1:pBhA0ybfXv6hDjQUZ7hk1lVxBiUbupdw5R31yPUViVQ=
 github.com/charmbracelet/x/input v0.3.5-0.20250424101541-abb4d9a9b197 h1:fsWj8NF5njyMVzELc7++HsvRDvgz3VcgGAUgWBDWWWM=
 github.com/charmbracelet/x/input v0.3.5-0.20250424101541-abb4d9a9b197/go.mod h1:xseGeVftoP9rVI+/8WKYrJFH6ior6iERGvklwwHz5+s=
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
@@ -63,6 +69,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -96,6 +104,8 @@ github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6T
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
 github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
+github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
+github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 h1:ZK8zHtRHOkbHy6Mmr5D264iyp3TiX5OmNcI5cIARiQI=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6/go.mod h1:CJlz5H+gyd6CUWT45Oy4q24RdLyn7Md9Vj2/ldJBSIo=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=

--- a/internal/enums/task.go
+++ b/internal/enums/task.go
@@ -2,6 +2,13 @@ package enums
 
 type TaskStatus int
 
+var TaskStatusMap map[TaskStatus]string = map[TaskStatus]string{
+	Pending:   "Pending",
+	Abandoned: "Abandoned",
+	Complete:  "Complete",
+	Started:   "Started",
+}
+
 const (
 	Pending = iota
 	Started

--- a/internal/enums/tasktype.go
+++ b/internal/enums/tasktype.go
@@ -2,7 +2,12 @@ package enums
 
 type TaskType int
 
+var TaskTypeMap map[TaskType]string = map[TaskType]string{
+	RecurringTask: "Recurring",
+	UniqueTask:    "Unique",
+}
+
 const (
-	RecurringTask = iota
-	UniqueTask
+	UniqueTask = iota
+	RecurringTask
 )

--- a/internal/models/daily/daily.go
+++ b/internal/models/daily/daily.go
@@ -18,7 +18,7 @@ type Daily struct {
 	Width     int
 	Height    int
 	List      list.Model
-	Tasks     Tasks
+	Tasks     []Task
 	Popup     *taskpopup.TaskPopup
 	ShowPopup bool
 	Keymap    keymap.DailyTaskMap
@@ -28,7 +28,7 @@ type Daily struct {
 func NewDaily(w int, h int) *Daily {
 	tasks := GetItems()
 
-	lst := list.New(tasks.ItemsAsList(), TaskDelegate{}, w/2, 2*h/3)
+	lst := list.New(TaskToItems(tasks), TaskDelegate{}, w/2, 2*h/3)
 	km := list.DefaultKeyMap()
 	km.Quit.Unbind()
 	lst.KeyMap = km
@@ -147,9 +147,7 @@ func (m *Daily) View() string {
 func (m *Daily) Refresh() {
 	m.Tasks = GetItems()
 
-	curr := m.Tasks.ItemsAsList()
-
-	lst := list.New(curr, TaskDelegate{}, m.Width/2, 2*m.Height/3)
+	lst := list.New(TaskToItems(m.Tasks), TaskDelegate{}, m.Width/2, 2*m.Height/3)
 	km := list.DefaultKeyMap()
 	km.Quit.Unbind()
 	lst.KeyMap = km

--- a/internal/models/daily/handlers.go
+++ b/internal/models/daily/handlers.go
@@ -15,10 +15,13 @@ func (m Daily) CreateTask(msg messages.TaskPopupMessage, isUnique bool) {
 	}
 
 	if isUnique {
-		m.Tasks.Unique = append(m.Tasks.Unique, task) // Seperate Task Input for recurring / unique tasks
+		task.TaskType = enums.UniqueTask
 	} else {
-		m.Tasks.Recurring = append(m.Tasks.Recurring, task) // Seperate Task Input for recurring / unique tasks
+		task.TaskType = enums.RecurringTask
 	}
+
+	m.Tasks = append(m.Tasks, task)
+
 	WriteItems(m.Tasks)
 }
 
@@ -34,12 +37,7 @@ func (m Daily) DeleteTask(msg messages.TaskPopupMessage) {
 		return
 	}
 
-	switch task.TaskType {
-	case enums.RecurringTask:
-		m.Tasks.Recurring = slices.Delete(m.Tasks.Recurring, task.Index, task.Index+1)
-	case enums.UniqueTask:
-		m.Tasks.Unique = slices.Delete(m.Tasks.Unique, task.Index, task.Index+1)
-	}
+	m.Tasks = slices.Delete(m.Tasks, task.ID, task.ID+1)
 
 	WriteItems(m.Tasks)
 }
@@ -54,12 +52,7 @@ func (m Daily) StatusChangeTask(msg messages.TaskPopupMessage) {
 
 	task.Status = msg.Status
 
-	switch task.TaskType {
-	case enums.RecurringTask:
-		m.Tasks.Recurring[task.Index] = task
-	case enums.UniqueTask:
-		m.Tasks.Unique[task.Index] = task
-	}
+	m.Tasks[task.ID] = task
 
 	WriteItems(m.Tasks)
 }
@@ -80,12 +73,7 @@ func (m Daily) EditTask(msg messages.TaskPopupMessage) {
 
 	task.Status = oldTask.Status
 
-	switch oldTask.TaskType {
-	case enums.RecurringTask:
-		m.Tasks.Recurring[oldTask.Index] = task
-	case enums.UniqueTask:
-		m.Tasks.Unique[oldTask.Index] = task
-	}
+	m.Tasks[oldTask.ID] = task
 
 	WriteItems(m.Tasks)
 }

--- a/internal/models/daily/items.go
+++ b/internal/models/daily/items.go
@@ -1,7 +1,6 @@
 package daily
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,62 +9,33 @@ import (
 	"github.com/SourcewareLab/Toney/internal/config"
 	"github.com/SourcewareLab/Toney/internal/enums"
 	"github.com/charmbracelet/bubbles/list"
+	"github.com/jszwec/csvutil"
 )
 
-type Tasks struct {
-	Recurring []Task       `json:"recurring"`
-	Unique    []Task       `json:"unique"`
-	Github    []GithubTask `json:"github"`
-}
-
-type GithubTask struct {
-	TaskTitle string           `json:"title"`
-	TaskDesc  string           `json:"desc"`
-	Status    enums.TaskStatus `json:"status"`
-	Ref       string           `json:"ref"`
-	Repo      string           `json:"repo"`
-	Owner     string           `json:"owner"`
-	// We will not store these data in the file
-	Link     string   `json:"-"`
-	Labels   []string `json:"-"`
-	Assignee []string `json:"-"`
-}
-
-func (m GithubTask) Title() string       { return m.TaskTitle }
-func (m GithubTask) Description() string { return m.TaskDesc }
-func (m GithubTask) FilterValue() string { return m.TaskTitle }
-
 type Task struct {
-	TaskTitle string           `json:"title"`
-	TaskDesc  string           `json:"desc"`
-	Status    enums.TaskStatus `json:"status"`
+	TaskTitle string           `csv:"title"`
+	TaskDesc  string           `csv:"desc"`
+	Status    enums.TaskStatus `csv:"status"`
 	// We will not store these data in the file
-	Index    int            `json:"-"` // Point to index in the respective type array
-	TaskType enums.TaskType `json:"-"`
+	ID       int            `csv:"-"` // Point to index in the respective type array
+	TaskType enums.TaskType `csv:"-"`
 }
 
 func (m Task) Title() string       { return m.TaskTitle }
 func (m Task) Description() string { return m.TaskDesc }
 func (m Task) FilterValue() string { return m.TaskTitle }
 
-func (m Tasks) ItemsAsList() []list.Item {
-	lst1 := TaskToItems(m.Recurring)
-	lst2 := TaskToItems(m.Unique)
-
-	return append(lst1, lst2...)
-}
-
 func TaskToItems(tasks []Task) []list.Item {
 	list := make([]list.Item, 0)
 	for i, v := range tasks {
-		v.Index = i
+		v.ID = i
 		v.TaskType = enums.RecurringTask
 		list = append(list, v)
 	}
 	return list
 }
 
-func GetItems() Tasks {
+func GetItems() []Task {
 	path := GetPath()
 
 	_, err := os.Stat(path)
@@ -80,12 +50,14 @@ func GetItems() Tasks {
 			fmt.Println(err2.Error())
 		}
 
-		tasks := Tasks{}
-		json.Unmarshal(content, &tasks)
+		tasks := make([]Task, 0)
+		csvutil.Unmarshal(content, &tasks)
 
-		tasks.Unique = make([]Task, 0)
+		for k := range tasks {
+			tasks[k].ID = k
+		}
 
-		data, err2 := json.Marshal(tasks)
+		data, err2 := csvutil.Marshal(tasks)
 		if err2 != nil {
 			fmt.Println(err2.Error())
 		}
@@ -97,9 +69,8 @@ func GetItems() Tasks {
 
 	content, _ := os.ReadFile(path)
 
-	tasks := Tasks{}
-
-	err = json.Unmarshal(content, &tasks)
+	tasks := make([]Task, 0)
+	err = csvutil.Unmarshal(content, &tasks)
 	if err != nil {
 		fmt.Println(err.Error())
 	}
@@ -107,10 +78,10 @@ func GetItems() Tasks {
 	return tasks
 }
 
-func WriteItems(tasks Tasks) {
+func WriteItems(tasks []Task) {
 	path := GetPath()
 
-	data, _ := json.Marshal(tasks)
+	data, _ := csvutil.Marshal(tasks)
 
 	os.WriteFile(path, data, 0o644)
 }

--- a/internal/models/daily/items.go
+++ b/internal/models/daily/items.go
@@ -28,7 +28,7 @@ func (m Task) FilterValue() string { return m.TaskTitle }
 func TaskToItems(tasks []Task) []list.Item {
 	list := make([]list.Item, 0)
 	for i, v := range tasks {
-		v.ID = i
+		v.ID = i + 1
 		v.TaskType = enums.RecurringTask
 		list = append(list, v)
 	}
@@ -54,7 +54,7 @@ func GetItems() []Task {
 		csvutil.Unmarshal(content, &tasks)
 
 		for k := range tasks {
-			tasks[k].ID = k
+			tasks[k].ID = k + 1
 		}
 
 		data, err2 := csvutil.Marshal(tasks)

--- a/internal/models/daily/items.go
+++ b/internal/models/daily/items.go
@@ -55,6 +55,7 @@ func GetItems() []Task {
 
 		for k := range tasks {
 			tasks[k].ID = k + 1
+			tasks[k].Status = enums.Pending
 		}
 
 		data, err2 := csvutil.Marshal(tasks)

--- a/internal/models/fileExplorer/fileExplorer.go
+++ b/internal/models/fileExplorer/fileExplorer.go
@@ -81,7 +81,7 @@ func (m *FileExplorer) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.CurrentNode = m.VisibleNodes[m.CurrentIndex]
 
 			// fmt.Println(m.CurrentIndex*5, m.Vp.YOffset+m.Vp.Height-5)
-			if m.CurrentIndex > m.Vp.YOffset+m.Vp.Height-5 {
+			if m.CurrentIndex > m.Vp.YOffset+m.Vp.Height-6 {
 				m.Vp.YOffset += 1
 			}
 

--- a/internal/styles/huhStyles.go
+++ b/internal/styles/huhStyles.go
@@ -1,0 +1,8 @@
+package styles
+
+import "github.com/charmbracelet/huh"
+
+func HuhTheme() *huh.Theme { // Do config/Docs for this
+	th := huh.ThemeCatppuccin()
+	return th
+}


### PR DESCRIPTION
Create CLI commands for :-

## Home
  - [x] Find (fuzzy)
    - exact match with -e/--exact flag
  - [x] Render
    - -r/--raw for raw
  - [x] Edit 
    - -c//--custom for custom editor, else config
  - [x] List
    - Recursive Listing of files
    - Does not show .* files unless -a/--all flag
    - Also supports rel path w/ -p/--path flag

## Tasks

  - [x] List
     - -v/--verbose for Descr printing as well
     - -r/--raw for raw json
  
  - [x] CRUD Tasks
    - w/ huh or other library
## Sync

- Git based file synchronization (similar to yadm)

If you wish to work on this, create a new issue for the specific CLI Command you want to work on, and then make a PR for that issue after some discussion.
Comment Any ideas for subcommands, more commands etc.