### PR TITLE
fix: move stop script execution to root command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,6 +54,25 @@ func RootCmd() *cobra.Command {
 			if _, err := p.Run(); err != nil {
 				fmt.Printf("Toney error: %v\n", err)
 			}
+
+			if len(config.AppConfig.General.StopScript) > 0 {
+				script := strings.Join(config.AppConfig.General.StopScript, " ")
+				var command *exec.Cmd
+
+				switch runtime.GOOS {
+				case "windows":
+					command = exec.Command("cmd", "/C", script)
+				default:
+					command = exec.Command("sh", "-c", script)
+				}
+
+				command.Stdout = os.Stdout
+				command.Stderr = os.Stderr
+
+				if err := command.Run(); err != nil {
+					log.Printf("Stop script execution error: %v\n", err)
+				}
+			}
 		},
 	}
 

--- a/internal/models/rootModel.go
+++ b/internal/models/rootModel.go
@@ -167,17 +167,6 @@ func (m *RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		case "ctrl+c":
-			// Stop script
-			script := strings.Join(config.AppConfig.General.StopScript, " ")
-			command := exec.Command("bash", "-c", script)
-
-			command.Stdout = os.Stdout
-			command.Stderr = os.Stderr
-
-			err := command.Run()
-			if err != nil {
-				return m, utils.ReturnError("Root", "Error Closing Editor", err)
-			}
 			return m, tea.Quit
 		}
 


### PR DESCRIPTION
The stop script was not running when exiting using the quit item in the menu. I moved the script execution to the root command after the Bubbletea program quits so the script gets ran both ways.