### PR TITLE
fix: remove extra filepath.Join() for config directory

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,9 +12,7 @@ import (
 var AppConfig Config
 
 func SetConfig() error {
-	cfg := getCfgDir()
-
-	configDir := filepath.Join(cfg, "toney")
+	configDir := getCfgDir()
 	configFile := filepath.Join(configDir, "config.toml")
 
 	// Create config directory if it doesn't exist


### PR DESCRIPTION
In `config.go` after ` getCfgDir()` returns it was using `filepath.Join()` to add an additional `toney` directory to the config path making the config dir `~/.config/toney/toney` instead of `~/.config/toney`.

This PR removes the extra `filepath.Join()`  and saves the results of `getCfgDir()` to `configDir`.