### PR TITLE
fix: fix daily tasks with correct offset for task ID

### DIFF
--- a/internal/models/daily/handlers.go
+++ b/internal/models/daily/handlers.go
@@ -37,7 +37,7 @@ func (m Daily) DeleteTask(msg messages.TaskPopupMessage) {
 		return
 	}
 
-	m.Tasks = slices.Delete(m.Tasks, task.ID, task.ID+1)
+	m.Tasks = slices.Delete(m.Tasks, task.ID-1, task.ID)
 
 	WriteItems(m.Tasks)
 }
@@ -52,7 +52,7 @@ func (m Daily) StatusChangeTask(msg messages.TaskPopupMessage) {
 
 	task.Status = msg.Status
 
-	m.Tasks[task.ID] = task
+	m.Tasks[task.ID-1] = task
 
 	WriteItems(m.Tasks)
 }
@@ -73,7 +73,7 @@ func (m Daily) EditTask(msg messages.TaskPopupMessage) {
 
 	task.Status = oldTask.Status
 
-	m.Tasks[oldTask.ID] = task
+	m.Tasks[oldTask.ID-1] = task
 
 	WriteItems(m.Tasks)
 }


### PR DESCRIPTION
Edit, update status, and delete for daily tasks in the TUI were causing an out of bounds error. This was due to incorrectly accounting for the offset of Task ID from not using a 0 indexed slice.

The CLI operations already accounted for this and worked fine.