### PR TITLE
fix: rollover tasks

### DIFF
--- a/internal/models/daily/items.go
+++ b/internal/models/daily/items.go
@@ -50,12 +50,16 @@ func GetItems() []Task {
 			fmt.Println(err2.Error())
 		}
 
-		tasks := make([]Task, 0)
-		csvutil.Unmarshal(content, &tasks)
+		allTasks := make([]Task, 0)
+		csvutil.Unmarshal(content, &allTasks)
 
-		for k := range tasks {
-			tasks[k].ID = k + 1
-			tasks[k].Status = enums.Pending
+		tasks := make([]Task, 0)
+		for _, task := range allTasks {
+			if task.Status == enums.Complete || task.Status == enums.Abandoned {
+				continue
+			}
+
+			tasks = append(tasks, task)
 		}
 
 		data, err2 := csvutil.Marshal(tasks)

--- a/internal/models/daily/items.go
+++ b/internal/models/daily/items.go
@@ -53,14 +53,7 @@ func GetItems() []Task {
 		allTasks := make([]Task, 0)
 		csvutil.Unmarshal(content, &allTasks)
 
-		tasks := make([]Task, 0)
-		for _, task := range allTasks {
-			if task.Status == enums.Complete || task.Status == enums.Abandoned {
-				continue
-			}
-
-			tasks = append(tasks, task)
-		}
+		tasks := filterRolloverTasks(allTasks)
 
 		data, err2 := csvutil.Marshal(tasks)
 		if err2 != nil {
@@ -102,4 +95,16 @@ func GetYesterdayPath() string {
 	home, _ := os.UserHomeDir()
 	yesterday := time.Now().AddDate(0, 0, -1).Format("2006-01-02")
 	return filepath.Join(home, config.AppConfig.General.NotesDir, ".daily", yesterday)
+}
+
+func filterRolloverTasks(tasks []Task) []Task {
+	result := make([]Task, 0)
+	for _, task := range tasks {
+		if task.Status == enums.Complete || task.Status == enums.Abandoned {
+			continue
+		}
+
+		result = append(result, task)
+	}
+	return result
 }

--- a/internal/models/daily/items_test.go
+++ b/internal/models/daily/items_test.go
@@ -1,0 +1,105 @@
+package daily
+
+import (
+	"testing"
+
+	"github.com/SourcewareLab/Toney/v2/internal/enums"
+)
+
+func TestFilterRolloverTasks(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []Task
+		expected []Task
+	}{
+		{
+			name:     "empty slice",
+			input:    []Task{},
+			expected: []Task{},
+		},
+		{
+			name: "all pending",
+			input: []Task{
+				{TaskTitle: "task1", Status: enums.Pending},
+				{TaskTitle: "task2", Status: enums.Pending},
+			},
+			expected: []Task{
+				{TaskTitle: "task1", Status: enums.Pending},
+				{TaskTitle: "task2", Status: enums.Pending},
+			},
+		},
+		{
+			name: "all started",
+			input: []Task{
+				{TaskTitle: "task1", Status: enums.Started},
+				{TaskTitle: "task2", Status: enums.Started},
+			},
+			expected: []Task{
+				{TaskTitle: "task1", Status: enums.Started},
+				{TaskTitle: "task2", Status: enums.Started},
+			},
+		},
+		{
+			name: "all complete",
+			input: []Task{
+				{TaskTitle: "task1", Status: enums.Complete},
+				{TaskTitle: "task2", Status: enums.Complete},
+			},
+			expected: []Task{},
+		},
+		{
+			name: "all abandoned",
+			input: []Task{
+				{TaskTitle: "task1", Status: enums.Abandoned},
+				{TaskTitle: "task2", Status: enums.Abandoned},
+			},
+			expected: []Task{},
+		},
+		{
+			name: "mixed statuses",
+			input: []Task{
+				{TaskTitle: "pending", Status: enums.Pending},
+				{TaskTitle: "started", Status: enums.Started},
+				{TaskTitle: "complete", Status: enums.Complete},
+				{TaskTitle: "abandoned", Status: enums.Abandoned},
+			},
+			expected: []Task{
+				{TaskTitle: "pending", Status: enums.Pending},
+				{TaskTitle: "started", Status: enums.Started},
+			},
+		},
+		{
+			name: "preserves fields",
+			input: []Task{
+				{TaskTitle: "my task", TaskDesc: "my description", Status: enums.Pending},
+			},
+			expected: []Task{
+				{TaskTitle: "my task", TaskDesc: "my description", Status: enums.Pending},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterRolloverTasks(tt.input)
+
+			if len(got) != len(tt.expected) {
+				t.Fatalf("filterRolloverTasks() length = %d, want %d", len(got), len(tt.expected))
+			}
+
+			for i := range got {
+				if got[i].TaskTitle != tt.expected[i].TaskTitle {
+					t.Errorf("filterRolloverTasks() [%d].TaskTitle = %q, want %q", i, got[i].TaskTitle, tt.expected[i].TaskTitle)
+				}
+
+				if got[i].TaskDesc != tt.expected[i].TaskDesc {
+					t.Errorf("filterRolloverTasks() [%d].TaskDesc = %q, want %q", i, got[i].TaskDesc, tt.expected[i].TaskDesc)
+				}
+
+				if got[i].Status != tt.expected[i].Status {
+					t.Errorf("filterRolloverTasks() [%d].Status = %d, want %d", i, got[i].Status, tt.expected[i].Status)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
`GetItems()` in `internal/models/daily/items.go` was rolling over all tasks from the prior day regardless of status. Since I expressed some opinions in this fix I want to break it out in case there needs to be discussion.

1. I am only rolling over pending and started tasks
2. Started tasks keep the started status (Bullet Journal ideology)
3. I extracted the filter to a helper function to make it testable
4. Added unit tests just for this change (I would like add tests for any new changes I make)

I am happy to make changes is this doesn't fit with your vision for the code.

If and when this is merged in please release.