### PR TITLE
fix: use enum values directly for task status color

### DIFF
--- a/internal/models/taskPopup/select.go
+++ b/internal/models/taskPopup/select.go
@@ -61,21 +61,21 @@ func (m *SelectStatus) View() string {
 }
 
 func (m SelectStatus) GetText() string {
-	text := ""
+	var text strings.Builder
 	style := lipgloss.NewStyle().Width(m.Width).Padding(0, 2).Foreground(colors.ColorPalette().Text)
 
 	for idx, val := range m.Opts {
-		line := m.Opts[val]
+		line := val
 		if m.Selected == idx {
-			text += style.Background(colors.ColorPalette().MenuSelectedBg).
+			text.WriteString(style.Background(colors.ColorPalette().MenuSelectedBg).
 				Foreground(colors.ColorPalette().MenuSelectedText).
-				Render(m.TitleMap[line]) + "\n"
+				Render(m.TitleMap[line]) + "\n")
 
 			continue
 		}
 
-		text += style.Render(m.TitleMap[line]) + "\n"
+		text.WriteString(style.Render(m.TitleMap[line]) + "\n")
 	}
 
-	return strings.TrimSuffix(text, "\n")
+	return strings.TrimSuffix(text.String(), "\n")
 }

--- a/internal/models/taskPopup/select_test.go
+++ b/internal/models/taskPopup/select_test.go
@@ -1,0 +1,68 @@
+package taskpopup
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SourcewareLab/Toney/v2/internal/enums"
+)
+
+func TestGetText(t *testing.T) {
+	titleMap := map[enums.TaskStatus]string{
+		enums.Pending:   "Pending",
+		enums.Started:   "Started",
+		enums.Complete:  "Complete",
+		enums.Abandoned: "Abandoned",
+	}
+
+	tests := []struct {
+		name           string
+		opts           []enums.TaskStatus
+		selected       int
+		expectedLabels []string
+	}{
+		{
+			name:           "default order",
+			opts:           []enums.TaskStatus{enums.Pending, enums.Started, enums.Abandoned, enums.Complete},
+			selected:       0,
+			expectedLabels: []string{"Pending", "Started", "Abandoned", "Complete"},
+		},
+		{
+			name:           "non-default order",
+			opts:           []enums.TaskStatus{enums.Complete, enums.Started, enums.Pending, enums.Abandoned},
+			selected:       0,
+			expectedLabels: []string{"Complete", "Started", "Pending", "Abandoned"},
+		},
+		{
+			name:           "selected last item",
+			opts:           []enums.TaskStatus{enums.Pending, enums.Started, enums.Abandoned, enums.Complete},
+			selected:       3,
+			expectedLabels: []string{"Pending", "Started", "Abandoned", "Complete"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := SelectStatus{
+				Width:    20,
+				Height:   10,
+				Opts:     tt.opts,
+				TitleMap: titleMap,
+				Selected: tt.selected,
+			}
+
+			got := s.GetText()
+			lines := strings.Split(got, "\n")
+
+			if len(lines) != len(tt.expectedLabels) {
+				t.Fatalf("GetText() returned %d lines, want %d", len(lines), len(tt.expectedLabels))
+			}
+
+			for i, expected := range tt.expectedLabels {
+				if !strings.Contains(lines[i], expected) {
+					t.Errorf("GetText() line %d = %q, want it to contain %q", i, lines[i], expected)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
`SelectStatus.GetText()` was using the array indices instead of the enum values. This caused the task colors to sometimes not match the correct status.

Fixes #83 

If and when merged, please release.