### PR TITLE
fix: add android to getCfgDir() switch

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,7 +45,7 @@ func SetConfig() error {
 
 func getCfgDir() string {
 	switch runtime.GOOS {
-	case "linux", "darwin":
+	case "linux", "darwin", "android":
 		home, _ := os.UserHomeDir()
 		return filepath.Join(home, ".config", "toney")
 	case "windows":


### PR DESCRIPTION
Add `android` to the switch statement to get the config directory.

Closes #89 