### PR TITLE
Feat/issue 80/sort folders top

### DIFF
--- a/internal/fileTree/fileTree.go
+++ b/internal/fileTree/fileTree.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -50,12 +51,19 @@ func buildTree(parent *Node, path string, depth int) (*Node, error) {
 		sort.Slice(node.Children, func(i, j int) bool {
 			a, b := node.Children[i], node.Children[j]
 
+			// Sort directories above files
 			priorityA, priorityB := sortPriority(a), sortPriority(b)
 			if priorityA != priorityB {
 				return priorityA < priorityB
 			}
 
-			return strings.ToLower(a.Name) < strings.ToLower(b.Name)
+			// Sort dates descending
+			nameA, nameB := strings.ToLower(a.Name), strings.ToLower(b.Name)
+			if startsWithDate(nameA) && startsWithDate(nameB) {
+				return nameB < nameA
+			}
+
+			return nameA < nameB
 		})
 	}
 
@@ -135,6 +143,12 @@ func ListFilesRel(baseDir string) ([]string, error) {
 		return nil, err
 	}
 	return relPaths, nil
+}
+
+var datePrefix = regexp.MustCompile(`^\d{4}-?\d{2}-?\d{2}`)
+
+func startsWithDate(name string) bool {
+	return datePrefix.MatchString(name)
 }
 
 func sortPriority(n *Node) int {

--- a/internal/fileTree/fileTree.go
+++ b/internal/fileTree/fileTree.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/SourcewareLab/Toney/v2/internal/colors"
@@ -45,6 +46,17 @@ func buildTree(parent *Node, path string, depth int) (*Node, error) {
 			child, _ := buildTree(&node, childPath, depth+1)
 			node.Children = append(node.Children, child)
 		}
+
+		sort.Slice(node.Children, func(i, j int) bool {
+			a, b := node.Children[i], node.Children[j]
+
+			priorityA, priorityB := sortPriority(a), sortPriority(b)
+			if priorityA != priorityB {
+				return priorityA < priorityB
+			}
+
+			return strings.ToLower(a.Name) < strings.ToLower(b.Name)
+		})
 	}
 
 	return &node, nil
@@ -123,4 +135,19 @@ func ListFilesRel(baseDir string) ([]string, error) {
 		return nil, err
 	}
 	return relPaths, nil
+}
+
+func sortPriority(n *Node) int {
+	isDot := strings.HasPrefix(n.Name, ".")
+
+	switch {
+	case isDot && n.IsDirectory:
+		return 0
+	case n.IsDirectory:
+		return 1
+	case isDot:
+		return 2
+	default:
+		return 3
+	}
 }

--- a/internal/fileTree/fileTree_test.go
+++ b/internal/fileTree/fileTree_test.go
@@ -25,3 +25,30 @@ func TestSortPriority(t *testing.T) {
 		})
 	}
 }
+
+func TestStartsWithDate(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"YYYYMMDD", "20260328", true},
+		{"YYYY-MM-DD", "2026-03-28", true},
+		{"YYYYMMDD with suffix", "20260328-standup.md", true},
+		{"YYYY-MM-DD with suffix", "2026-03-28-standup.md", true},
+		{"regular file", "todo.md", false},
+		{"short number", "2026", false},
+		{"dot file", ".gitignore", false},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := startsWithDate(tt.input)
+			if got != tt.expected {
+				t.Errorf("startsWithDate(%q) = %v, want %v",
+					tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/fileTree/fileTree_test.go
+++ b/internal/fileTree/fileTree_test.go
@@ -1,0 +1,27 @@
+package filetree
+
+import "testing"
+
+func TestSortPriority(t *testing.T) {
+	tests := []struct {
+		name     string
+		node     Node
+		expected int
+	}{
+		{"dot directory", Node{Name: ".git", IsDirectory: true}, 0},
+		{"dot directory with longer name", Node{Name: ".obsidian", IsDirectory: true}, 0},
+		{"regular directory", Node{Name: "journal", IsDirectory: true}, 1},
+		{"dot file", Node{Name: ".gitignore", IsDirectory: false}, 2},
+		{"regular file", Node{Name: "todo.md", IsDirectory: false}, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sortPriority(&tt.node)
+			if got != tt.expected {
+				t.Errorf("sortPriority(%q, IsDirectory=%v) = %d, want %d",
+					tt.node.Name, tt.node.IsDirectory, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I changed the way directories and files are sorted in the file tree:

1. dot directories > directories > dotfiles > files
2. File and directories that start with a YYYYMMDD or YYYY-MM-DD format are sorted descending

Closes #80 