### PR TITLE
bugfix(delete): change os.Remove to os.RemoveAll

### DIFF
--- a/internal/models/filePopup/handlers.go
+++ b/internal/models/filePopup/handlers.go
@@ -65,7 +65,7 @@ func Delete(path string, value string) error {
 		return nil
 	}
 
-	err := os.Remove(path)
+	err := os.RemoveAll(path)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#79 

Fixes the issue where trying to delete a non-empty directory fails. Changed os.Remove to os.RemoveAll to ensure nested files are removed properly.

Note: As a future improvement, we could create a new enum in popuptype named DirDelete to customize the message between "delete dir" and "delete file".